### PR TITLE
Correct and check the moms payload

### DIFF
--- a/dupla/abstract_payload.py
+++ b/dupla/abstract_payload.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 from .api_keys import DuplaApiKeys
-from .timestamp import as_utc_str
+from .timestamp import as_utc
 
 ALIAS_MAPPING: Dict[str, str] = {
     "default_endpoint": "default_endpoint",
@@ -72,4 +72,4 @@ class UdstillingMixin(BaseModel, abc.ABC):
     def serialize_udstilling(self, dt: Optional[datetime]) -> Optional[str]:
         if dt is None:
             return dt
-        return as_utc_str(dt)
+        return as_utc(dt).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/dupla/abstract_payload.py
+++ b/dupla/abstract_payload.py
@@ -60,15 +60,11 @@ class BasePayload(BaseModel, abc.ABC):
 
 
 class UdstillingMixin(BaseModel, abc.ABC):
-    model_config = ConfigDict(alias_generator=_get_alias, populate_by_name=True, extra="forbid")
-
     udstilling_fra: Optional[datetime] = Field(
         default=None,
-        serialization_alias=DuplaApiKeys.UDSTILLING_FRA,
     )
     udstilling_til: Optional[datetime] = Field(
         default=None,
-        serialization_alias=DuplaApiKeys.UDSTILLING_TIL,
     )
 
     @field_serializer("udstilling_fra")

--- a/dupla/abstract_payload.py
+++ b/dupla/abstract_payload.py
@@ -67,8 +67,7 @@ class UdstillingMixin(BaseModel, abc.ABC):
         default=None,
     )
 
-    @field_serializer("udstilling_fra")
-    @field_serializer("udstilling_til")
+    @field_serializer("udstilling_fra", "udstilling_til")
     def serialize_udstilling(self, dt: Optional[datetime]) -> Optional[str]:
         if dt is None:
             return dt

--- a/dupla/payload.py
+++ b/dupla/payload.py
@@ -45,7 +45,7 @@ class LigPayload(BasePayload):
     registrering_til: Optional[date] = Field(default=None)
 
 
-class MomsPayload(BasePayload, UdstillingMixin):
+class MomsPayload(UdstillingMixin, BasePayload):
     """An API client for Dataudstillingsplatformens (DUPLA) Momsangivelser API."""
 
     default_endpoint: ENDP_T = "Momsangivelse"

--- a/dupla/timestamp.py
+++ b/dupla/timestamp.py
@@ -15,7 +15,3 @@ def get_dk_now() -> datetime:
 
 def as_utc(ts: datetime) -> datetime:
     return ts.astimezone(TZ_UTC)
-
-
-def as_utc_str(ts: datetime) -> str:
-    return as_utc(ts).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -233,4 +233,7 @@ def test_mom_udstilling(faker):
         fmt = dateutil.parser.parse(dct[key])
         assert fmt.tzname() == "UTC"
         exp = payload[key]
-        assert fmt.astimezone(TZ_UTC) == exp  # astimezone to fix py 3.9 test
+        assert fmt.date() == exp.date()
+        assert fmt.hour == exp.hour
+        assert fmt.minute == exp.minute
+        assert fmt.second == exp.second

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -233,4 +233,4 @@ def test_mom_udstilling(faker):
         fmt = dateutil.parser.parse(dct[key])
         assert fmt.tzname() == "UTC"
         exp = payload[key]
-        assert fmt == exp
+        assert fmt.astimezone(TZ_UTC) == exp  # astimezone to fix py 3.9 test

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,7 +117,7 @@ def test_get_payload(faker):
     val = payload[dp.DuplaApiKeys.TEKNISK_REGISTRERING_FRA]
     assert isinstance(val, str)
     assert val == str(to_date)
-    assert datetime.fromisoformat(val).date() == to_date
+    assert dateutil.parser.parse(val).date() == to_date
 
 
 def test_payload_bad_arg(faker):
@@ -170,7 +170,7 @@ def test_moms_datetime(faker, as_iso: bool):
         assert obj.udstilling_til == dt
         payload = obj.get_payload()
         assert DuplaApiKeys.UDSTILLING_TIL in payload
-        assert datetime.fromisoformat(payload[DuplaApiKeys.UDSTILLING_TIL]) == dt
+        assert pytest.approx(dt) == dateutil.parser.parse(payload[DuplaApiKeys.UDSTILLING_TIL])
 
         assert isinstance(payload[DuplaApiKeys.AFREGNING_START], str)
         assert payload[DuplaApiKeys.AFREGNING_START] == str(dt.date())
@@ -233,7 +233,4 @@ def test_mom_udstilling(faker):
         fmt = dateutil.parser.parse(dct[key])
         assert fmt.tzname() == "UTC"
         exp = payload[key]
-        assert fmt.date() == exp.date()
-        assert fmt.hour == exp.hour
-        assert fmt.minute == exp.minute
-        assert fmt.second == exp.second
+        assert pytest.approx(fmt) == exp

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import Type
 
 import pytest
@@ -210,3 +210,17 @@ def test_other_invalid_se():
 )
 def test_int_or_string(input):
     dp.payload.KtrPayload(se=input)
+
+
+def test_mom_udstilling(faker):
+    payload = {
+        DuplaApiKeys.SE: get_fake_se(n=5),
+        DuplaApiKeys.AFREGNING_START: "1970-01-01",
+        DuplaApiKeys.AFREGNING_SLUT: date.today(),
+        DuplaApiKeys.UDSTILLING_FRA: faker.date_time(),
+        DuplaApiKeys.UDSTILLING_TIL: faker.date_time(),
+    }
+    m = dp.payload.MomsPayload(**payload)
+    assert isinstance(m, dp.payload.MomsPayload)
+    assert isinstance(m.udstilling_til, datetime)
+    assert isinstance(m.udstilling_fra, datetime)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import date, datetime, timedelta
 from typing import Type
 
+import dateutil.parser
 import pytest
 from faker import Faker
 from pydantic import BaseModel, ValidationError
@@ -229,6 +230,7 @@ def test_mom_udstilling(faker):
     dct = m.get_payload()
     for key in [DuplaApiKeys.UDSTILLING_FRA, DuplaApiKeys.UDSTILLING_TIL]:
         assert isinstance(dct[key], str)
-        fmt = datetime.fromisoformat(dct[key])
+        fmt = dateutil.parser.parse(dct[key])
+        assert fmt.tzname() == "UTC"
         exp = payload[key]
         assert fmt == exp


### PR DESCRIPTION
Fixes the MomsPayload. Pydantic model wasn't validated correctly, and the serialization wasn't serializing one of the fields.

Also adds tests to verify correctness.