### PR TITLE
Add optional 'onbehalfofse' to _authenticate payload #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ api = dupla.DuplaAccess(
     pkcs12_filename="path-to-cert-file",
     pkcs12_password="goodpassword",
     billetautomat_url="https://bat.skat.dk/realms/oces/protocol/openid-connect/token",
-    jwt_token_expiration_overlap=5
+    jwt_token_expiration_overlap=5,
+    onbehalfofse = "98765432" #Optional
 )
 
 # lets see if this company (se_number 98765432) has done any VAT the last year

--- a/dupla/endpoint.py
+++ b/dupla/endpoint.py
@@ -30,6 +30,7 @@ class DuplaAccess(DuplaApiBase):
         base_url: str = r"https://api.skat.dk",
         jwt_token_expiration_overlap: int = 5,
         max_tries: int = 8,
+        onbehalfofse: Optional[str] = None,
     ):
         """Instantiates new DUPLA API endpoint client.
         Args:
@@ -46,10 +47,15 @@ class DuplaAccess(DuplaApiBase):
                 and will be rejected in a next request. Defaults to 5 seconds.
             max_tries (int): Maximum number of times a failed request is re-attempted in
                 ``get_data``. Defaults to 8.
+            onbehalfofse (Optional[str]): Optional SE number to include in authentication payload.
         """
 
         self.base_url = base_url
         self.max_tries = max_tries
+        # store value by passing it into the base initializer. If we set
+        # `self.onbehalfofse` here and then call `super().__init__()` which
+        # also sets the attribute (with its own parameter), our value would be
+        # overwritten. Passing it through avoids that.
         super().__init__(
             transaction_id,
             agreement_id,
@@ -57,6 +63,7 @@ class DuplaAccess(DuplaApiBase):
             pkcs12_password,
             billetautomat_url,
             jwt_token_expiration_overlap,
+            onbehalfofse=onbehalfofse,
         )
 
     def get_endpoint(self, payload: BasePayload) -> str:

--- a/tests/test_authenticate_onbehalfofse.py
+++ b/tests/test_authenticate_onbehalfofse.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from uuid import uuid4
+from dupla.endpoint import DuplaAccess
+
+@pytest.fixture
+def client_with_onbehalfofse():
+    return DuplaAccess(
+        transaction_id=str(uuid4()),
+        agreement_id="dummy-agreement",
+        pkcs12_filename="dummy.p12",
+        pkcs12_password="dummy",
+        billetautomat_url="https://fake-url.com",
+        onbehalfofse="987654321",  # optional
+    )
+
+@pytest.fixture
+def client_without_onbehalfofse():
+    return DuplaAccess(
+        transaction_id=str(uuid4()),
+        agreement_id="dummy-agreement",
+        pkcs12_filename="dummy.p12",
+        pkcs12_password="dummy",
+        billetautomat_url="https://fake-url.com",
+    )
+
+@patch("dupla.base.requests.Session")
+def test_authenticate_includes_onbehalfofse(mock_session, client_with_onbehalfofse):
+    mock_result = MagicMock()
+    mock_result.ok = True
+    mock_result.json.return_value = {"access_token": "token123", "expires_in": 3600}
+
+    mock_session.return_value.__enter__.return_value.post.return_value = mock_result
+
+    client_with_onbehalfofse._authenticate()
+
+    _, kwargs = mock_session.return_value.__enter__.return_value.post.call_args
+    assert kwargs["data"]["onbehalfofse"] == "987654321"
+
+@patch("dupla.base.requests.Session")
+def test_authenticate_works_without_onbehalfofse(mock_session, client_without_onbehalfofse):
+    mock_result = MagicMock()
+    mock_result.ok = True
+    mock_result.json.return_value = {"access_token": "token456", "expires_in": 3600}
+
+    mock_session.return_value.__enter__.return_value.post.return_value = mock_result
+
+    client_without_onbehalfofse._authenticate()
+
+    _, kwargs = mock_session.return_value.__enter__.return_value.post.call_args
+    assert "onbehalfofse" not in kwargs["data"]


### PR DESCRIPTION
- Updated DuplaAccess and DuplaApiBase to accept an optional 'onbehalfofse' argument.
- '_authenticate' now includes 'onbehalfofse' in the payload if provided.
- Existing behavior is fully backwards-compatible when 'onbehalfofse' is not set.
- Added unit tests to cover both scenarios:
  - authentication with 'onbehalfofse'
  - authentication without 'onbehalfofse'

This change allows users to authenticate on behalf of another SE number when required by the API.