### PR TITLE
Add timeouts (default 30s) to requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 ### Added
+ - Added timeout to `request` and `session.post` calls. Defaults to 30s.
+
 
 ## 0.2.1
 ### Changed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ api = dupla.DuplaAccess(
     pkcs12_filename="path-to-cert-file",
     pkcs12_password="goodpassword",
     billetautomat_url="https://bat.skat.dk/realms/oces/protocol/openid-connect/token",
-    jwt_token_expiration_overlap=5
+    jwt_token_expiration_overlap=5,
+    timeout=30.0  # Optional, default: 30.0
 )
 
 # lets see if this company (se_number 98765432) has done any VAT the last year

--- a/dupla/base.py
+++ b/dupla/base.py
@@ -30,6 +30,12 @@ class DuplaApiBase:
         jwt_token_expiration_overlap (int): The overlap time for token expiration time (in seconds)
             to avoid situations where token is almost expired during the check and will be rejected
             in a next request.
+        timeout (float): Timeout [s] for HTTP requests. Default: 30s.
+            Please note:
+                - Timeout is packet-to-packet timeout. See
+                https://requests.readthedocs.io/en/stable/user/quickstart/#timeouts .
+                - Timeout affects the inner loop of retries. So more retries (`max_retries`)
+                the longer total timeout effect.
     """
 
     transaction_id: str
@@ -44,6 +50,7 @@ class DuplaApiBase:
         pkcs12_password: str,
         billetautomat_url: str,
         jwt_token_expiration_overlap: int,
+        timeout: float = 30.0,
     ):
         self.transaction_id = transaction_id
         self.agreement_id = agreement_id
@@ -54,6 +61,7 @@ class DuplaApiBase:
         )
         self.billetautomat_url = billetautomat_url
         self.jwt_token_expiration_overlap = jwt_token_expiration_overlap
+        self.timeout = timeout
         self.token_expiration_time: Optional[datetime] = None
         self.jwt_token: Optional[str] = None
 
@@ -86,6 +94,7 @@ class DuplaApiBase:
 
         with requests.Session() as session:
             session.headers.update(headers)
+            kwargs.setdefault("timeout", self.timeout)
 
             return session.request(method, url, **kwargs)
 
@@ -120,7 +129,9 @@ class DuplaApiBase:
 
         with requests.Session() as session:
             session.mount(self.billetautomat_url, self._pkcs12_adapter)
-            result = session.post(self.billetautomat_url, headers=headers, data=payload)
+            result = session.post(
+                self.billetautomat_url, headers=headers, data=payload, timeout=self.timeout
+            )
             if result.ok:
                 result_payload = result.json()
             else:

--- a/dupla/endpoint.py
+++ b/dupla/endpoint.py
@@ -32,6 +32,7 @@ class DuplaAccess(DuplaApiBase):
         base_url: str = r"https://api.skat.dk",
         jwt_token_expiration_overlap: int = 5,
         max_tries: int = 8,
+        timeout: float = 30.0,
     ):
         """Instantiates new DUPLA API endpoint client.
         Args:
@@ -48,6 +49,12 @@ class DuplaAccess(DuplaApiBase):
                 and will be rejected in a next request. Defaults to 5 seconds.
             max_tries (int): Maximum number of times a failed request is re-attempted in
                 ``get_data``. Defaults to 8.
+            timeout (float): Timeout [s] for HTTP requests. Default: 30s.
+                Please note:
+                  - Timeout is packet-to-packet timeout. See
+                    https://requests.readthedocs.io/en/stable/user/quickstart/#timeouts .
+                  - Timeout affects the inner loop of retries. So more retries (`max_retries`)
+                    the longer total timeout effect.
         """
 
         self.base_url = base_url
@@ -59,6 +66,7 @@ class DuplaAccess(DuplaApiBase):
             pkcs12_password,
             billetautomat_url,
             jwt_token_expiration_overlap,
+            timeout,
         )
 
     def get_endpoint(self, payload: BasePayload) -> str:


### PR DESCRIPTION
Added timeout to `request` and `session.post` calls. Defaults to 30s.
